### PR TITLE
Template syntax tweaks

### DIFF
--- a/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
+++ b/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
@@ -28,8 +28,8 @@ extension ___VARIABLE_moduleName___Interactor: ___VARIABLE_moduleName___Interact
       if let result = data as? [String: AnyObject] {
         resp.response___VARIABLE_moduleName___InteractorResponseSuccess(response: ___VARIABLE_moduleName___Model.parse(with: result))
       }
-    }) { _ in      
+    }, failure: { _ in
       resp.response___VARIABLE_moduleName___InteractorResponseError()
-    }
+    })
   }
 }

--- a/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Provider.swift
+++ b/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Provider.swift
@@ -37,8 +37,8 @@ extension ___VARIABLE_moduleName___Provider: ___VARIABLE_moduleName___ProviderPr
   func get___VARIABLE_moduleName___(with params: [String: AnyObject], success: @escaping BaseSuccessCallback, failure: @escaping BaseFailureCallback) {        
     BaseProvider().request(method: method, endPoint: path, params: params, successBlock: { response in      
       success(response)
-    }) { error in
+    }, failure: { error in
       failure(error)
-    }
+    })
   }
 }

--- a/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Provider.swift
+++ b/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___Provider.swift
@@ -10,10 +10,10 @@
 import Foundation
 
 enum ___VARIABLE_moduleName___Provider {
-  
+
   // MARK: - Cases
   case caseBase
-  
+
   // MARK: - Path
   private var path: String {
     switch self {
@@ -21,7 +21,7 @@ enum ___VARIABLE_moduleName___Provider {
       return "site.com/api/xpto?query"
     }
   }
-  
+
   // MARK: - Methods
   private var method: HTTPMethod {
     switch self {
@@ -29,13 +29,13 @@ enum ___VARIABLE_moduleName___Provider {
       return .get
     }
   }
-  
+
 }
 
 // MARK: - Extensions
-extension ___VARIABLE_moduleName___Provider: ___VARIABLE_moduleName___ProviderProtocol {    
-  func get___VARIABLE_moduleName___(with params: [String: AnyObject], success: @escaping BaseSuccessCallback, failure: @escaping BaseFailureCallback) {        
-    BaseProvider().request(method: method, endPoint: path, params: params, successBlock: { response in      
+extension ___VARIABLE_moduleName___Provider: ___VARIABLE_moduleName___ProviderProtocol {
+  func get___VARIABLE_moduleName___(with params: [String: AnyObject], success: @escaping <#success callback#>, failure: @escaping  <#failure callback#>) {
+    <#Base Provider#>().request(method: method, endPoint: path, params: params, successBlock: { response in
       success(response)
     }, failure: { error in
       failure(error)

--- a/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___ProviderProtocol.swift
+++ b/Templates/File Templates/VIPERbr/Module.xctemplate/UIViewController/___FILEBASENAME___ProviderProtocol.swift
@@ -11,6 +11,6 @@ import Foundation
 
 protocol ___VARIABLE_moduleName___ProviderProtocol {
   func get___VARIABLE_moduleName___(with params: [String: AnyObject],
-                                    success: @escaping BaseSuccessCallback,
-                                    failure: @escaping BaseFailureCallback)
+                                    success: @escaping <#success callback#>,
+                                    failure: @escaping <#failure callback#>)
 }


### PR DESCRIPTION
- Removed unnamed trailing closures from the methods with more than one closure parameter

> Reference: [Closure Expression](https://github.com/raywenderlich/swift-style-guide#closure-expressions)

- Added some placeholders indicating where the methods COULD be changed in order to adapt to one's project.